### PR TITLE
Remove libsqlite_jni from all product configs.

### DIFF
--- a/target/product/core_minimal.mk
+++ b/target/product/core_minimal.mk
@@ -63,7 +63,6 @@ PRODUCT_PACKAGES += \
     libfilterfw \
     libkeystore \
     libgatekeeper \
-    libsqlite_jni \
     libwilhelm \
     logd \
     make_ext4fs \

--- a/target/product/core_tiny.mk
+++ b/target/product/core_tiny.mk
@@ -64,7 +64,6 @@ PRODUCT_PACKAGES += \
     libfilterfw \
     libgatekeeper \
     libkeystore \
-    libsqlite_jni \
     libwilhelm \
     libdrmframework_jni \
     libdrmframework \


### PR DESCRIPTION
It's only used by libcore tests so there's no need to ship it on
all products.

bug: 26457850
Change-Id: I907f781d215e94e1cbf554d81fda9e6eed07a4de
